### PR TITLE
fix: set SIZE_T_MAX to UINT_MAX on GNU platforms

### DIFF
--- a/include/share/alloc.h
+++ b/include/share/alloc.h
@@ -56,6 +56,8 @@
 #   else
 #    define SIZE_T_MAX 0xffffffff
 #   endif
+#  elif defined __GNUC__
+#   define SIZE_T_MAX UINT_MAX
 #  else
 #   error
 #  endif


### PR DESCRIPTION
On some Linux platforms, the header ``stdint.h`` does not define ``SIZE_T_MAX``, causing the build to fail.